### PR TITLE
Feature/pass env file

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,8 +26,6 @@ WORKDIR /app
 
 COPY --from=build /app/dist/dma-as .
 
-EXPOSE 3000
-
 LABEL org.opencontainers.image.source=https://github.com/dnd-mapp/dma-as
 LABEL org.opencontainers.image.description="Image containing the DnD-Mapp Authentication Server"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,18 +6,17 @@ COPY package*.json .
 
 RUN npm ci
 
-RUN npx prisma generate
-
 COPY . .
 
 RUN npm run build
 
 ENV NODE_ENV=production
 
-RUN mv node_modules/.prisma prisma-client/ && \
+RUN rm -rf node_modules && \
+    mv prisma dist/dma-as/prisma/ && \
     cd dist/dma-as && \
     npm i && \
-    mv ../../prisma-client node_modules/.prisma/
+    npx prisma generate
 
 
 FROM node:22.14-alpine3.21

--- a/.docker/compose.yml
+++ b/.docker/compose.yml
@@ -3,5 +3,7 @@ services:
         container_name: authentication-server
         image: dnd-mapp/dma-as:latest
         restart: on-failure
+        env_file:
+            - .env
         ports:
             - '3000:3000/tcp'

--- a/.idea/runConfigurations/docker_build.xml
+++ b/.idea/runConfigurations/docker_build.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="docker-build" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="docker-build" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,8 +2,9 @@
  * This is your Prisma schema file, learn more about it in the docs: https://pris.ly/d/prisma-schema
  */
 generator client {
-    provider = "prisma-client-js"
-    output   = "../node_modules/.prisma/client"
+    provider      = "prisma-client-js"
+    output        = "../node_modules/.prisma/client"
+    binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {

--- a/src/app/database/database.service.ts
+++ b/src/app/database/database.service.ts
@@ -1,9 +1,13 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { BeforeApplicationShutdown, Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class DatabaseService extends PrismaClient implements OnModuleInit {
+export class DatabaseService extends PrismaClient implements OnModuleInit, BeforeApplicationShutdown {
     public async onModuleInit() {
         this.$connect();
+    }
+
+    public async beforeApplicationShutdown() {
+        await this.$disconnect();
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,11 @@ async function bootstrap() {
         bufferLogs: true,
     });
     const logger = app.get(DmaLogger);
+    app.useLogger(logger);
+
     app.useGlobalPipes(new ValidationPipe(globalValidationOptions));
 
-    app.useLogger(logger);
+    app.enableShutdownHooks();
 
     await app.listen(port, host);
     logger.log(


### PR DESCRIPTION
* Adjust example to pass env file to Docker container
* Fix generating Prisma client while building Docker image
* Add binary targets for Prisma client so that it can run inside Docker containers.
* Enable and use shutdown hooks to disconnect from database before application shutdown in order to speed up removal of Docker containers.