### PR TITLE
Feature/use refresh tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "bcryptjs": "~3.0.0",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.14.1",
+                "nanoid": "~5.1.0",
                 "reflect-metadata": "~0.2.0",
                 "rxjs": "~7.8.0"
             },
@@ -10117,6 +10118,24 @@
             "license": "ISC",
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
             }
         },
         "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "bcryptjs": "~3.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "nanoid": "~5.1.0",
         "reflect-metadata": "~0.2.0",
         "rxjs": "~7.8.0"
     },

--- a/src/app/authentication/authentication.controller.ts
+++ b/src/app/authentication/authentication.controller.ts
@@ -85,8 +85,14 @@ export class AuthenticationController {
     @Post('/change-password')
     @HttpCode(HttpStatus.OK)
     @UseGuards(AuthenticationGuard)
-    public async changePassword(@Body() data: ChangePasswordData, @Req() request: FastifyRequest) {
+    public async changePassword(
+        @Body() data: ChangePasswordData,
+        @Req() request: FastifyRequest,
+        @Res({ passthrough: true }) response: FastifyReply
+    ) {
         this.logger.log(`Change password initiated for username "${request.authenticatedUser.username}"`);
         await this.authenticationService.changePassword(data, request.authenticatedUser);
+
+        response.clearCookie(COOKIE_NAME_ACCESS_TOKEN).clearCookie(COOKIE_NAME_REFRESH_TOKEN);
     }
 }

--- a/src/app/authentication/authentication.controller.ts
+++ b/src/app/authentication/authentication.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '../shared';
 import { AuthenticationGuard } from './authentication.guard';
 import { AuthenticationService } from './authentication.service';
+import { retrieveSignedCookieValue } from './functions';
 
 @Controller()
 @UseInterceptors(ClassSerializerInterceptor)
@@ -67,8 +68,13 @@ export class AuthenticationController {
     }
 
     @Post('/token')
-    public async token(@Body() data: TokenRequestData, @Res({ passthrough: true }) response: FastifyReply) {
-        const { accessToken, refreshToken } = await this.authenticationService.requestToken(data);
+    public async token(
+        @Body() data: TokenRequestData,
+        @Req() request: FastifyRequest,
+        @Res({ passthrough: true }) response: FastifyReply
+    ) {
+        const receivedRefreshToken = retrieveSignedCookieValue(request, COOKIE_NAME_REFRESH_TOKEN, this.logger);
+        const { accessToken, refreshToken } = await this.authenticationService.requestToken(data, receivedRefreshToken);
 
         response
             .status(HttpStatus.OK)

--- a/src/app/authentication/functions.ts
+++ b/src/app/authentication/functions.ts
@@ -3,57 +3,77 @@ import { ModuleRef } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { FastifyRequest } from 'fastify';
 import { DmaLogger } from '../logging';
-import { COOKIE_NAME_ACCESS_TOKEN, DecodedToken } from '../shared';
+import { DecodedToken } from '../shared';
 import { TokensService } from './tokens.service';
 
-export async function validateCookie(request: FastifyRequest, moduleRef: ModuleRef, logger: DmaLogger) {
+export function retrieveSignedCookieValue(request: FastifyRequest, cookieName: string, logger: DmaLogger) {
+    const cookie = request.cookies[cookieName];
+
+    if (!cookie) {
+        logger.warn('Token not accepted - Reason: Token is missing');
+        throw new UnauthorizedException('Unauthorized');
+    }
+    const unsignedCookie = request.unsignCookie(cookie);
+
+    if (!unsignedCookie.valid) {
+        logger.warn('Token not accepted - Reason: Something went wrong while unsinging the cookie');
+        throw new UnauthorizedException('Unauthorized');
+    }
+    return unsignedCookie.value;
+}
+
+export async function decodeToken(token: string, moduleRef: ModuleRef, logger: DmaLogger) {
     const jwtService = moduleRef.get(JwtService, { strict: false });
     const tokensService = moduleRef.get(TokensService, { strict: false });
 
-    const accessTokenCookie = request.cookies[COOKIE_NAME_ACCESS_TOKEN];
-
-    if (!accessTokenCookie) {
-        logger.warn('Access token not accepted - Reason: Missing access token');
-        throw new UnauthorizedException('Unauthorized');
-    }
-    const unsignedAccessTokenCookie = request.unsignCookie(accessTokenCookie);
-
-    if (!unsignedAccessTokenCookie.valid) {
-        logger.warn('Access token not accepted - Reason: Something went wrong while unsinging the access token cookie');
-        throw new UnauthorizedException('Unauthorized');
-    }
     let decodedToken: DecodedToken = null;
 
     try {
-        decodedToken = await jwtService.verifyAsync<DecodedToken>(unsignedAccessTokenCookie.value);
+        decodedToken = await jwtService.verifyAsync<DecodedToken>(token);
     } catch (error) {
-        logger.warn(`Access token not accepted - Reason: ${(error as Error).message}`);
+        logger.warn(`Token not accepted - Reason: ${(error as Error).message}`);
         throw new UnauthorizedException('Unauthorized');
     }
 
     if (decodedToken.header.alg !== 'RS256') {
-        logger.warn('Access token not accepted - Reason: Invalid token algorithm');
+        logger.warn('Token not accepted - Reason: Invalid token algorithm');
         throw new UnauthorizedException('Unauthorized');
     }
     if (decodedToken.payload.iss !== 'dnd-mapp/authentication-server') {
-        logger.warn(`Access token not accepted - Reason: "${decodedToken.payload.iss}" is not a valid token issuer`);
+        logger.warn(`Token not accepted - Reason: "${decodedToken.payload.iss}" is not a valid token issuer`);
         throw new UnauthorizedException('Unauthorized');
     }
-    if (Date.now() / 1000 < decodedToken.payload.exp) {
-        logger.warn('Access token not accepted - Reason: Access token has expired');
+    if (Date.now() >= decodedToken.payload.exp * 1000) {
+        logger.warn('Token not accepted - Reason: Token has expired');
         throw new UnauthorizedException('Unauthorized');
     }
     const storedToken = await tokensService.getById(decodedToken.payload.jti);
 
     if (!storedToken) {
-        logger.warn(`Access token not accepted - Reason: Token with ID "${decodedToken.payload.jti}" does not exist`);
+        logger.warn(`Token not accepted - Reason: Token with ID "${decodedToken.payload.jti}" does not exist`);
         throw new UnauthorizedException('Unauthorized');
     }
     if (storedToken.rvk) {
-        logger.warn(`Access token not accepted - Reason: Token with ID "${decodedToken.payload.jti}" is revoked`);
-        // TODO: Remove all tokens that are related to this token.
+        logger.warn(`Token not accepted - Reason: Token with ID "${decodedToken.payload.jti}" is revoked`);
+        await tokensService.removeRevokedToken(decodedToken.payload.jti, decodedToken.payload.pti);
         throw new UnauthorizedException('Unauthorized');
     }
-    logger.log('Access token accepted');
-    return storedToken.user;
+    return storedToken;
+}
+
+interface ValidateCookieParams {
+    request: FastifyRequest;
+    cookieName: string;
+    moduleRef: ModuleRef;
+    logger: DmaLogger;
+}
+
+export async function validateCookie(params: ValidateCookieParams) {
+    const { request, cookieName, moduleRef, logger } = params;
+
+    const cookieValue = retrieveSignedCookieValue(request, cookieName, logger);
+    const decodedToken = await decodeToken(cookieValue, moduleRef, logger);
+
+    logger.log('Token accepted');
+    return decodedToken;
 }

--- a/src/app/authentication/tokens.repository.ts
+++ b/src/app/authentication/tokens.repository.ts
@@ -13,6 +13,15 @@ export class TokensRepository {
             await this.databaseService.token.findFirst({ where: { jti: jti }, include: { user: true } })
         );
 
+    public findAllByPti = async (pti: string) =>
+        plainToInstance(TokenMetadata, await this.databaseService.token.findMany({ where: { pti: pti } }));
+
+    public findAllByUserIdAndNotRevoked = async (userId: string) =>
+        plainToInstance(
+            TokenMetadata,
+            await this.databaseService.token.findMany({ where: { AND: [{ sub: userId }, { rvk: false }] } })
+        );
+
     public create = async (metadata: TokenMetadata) =>
         plainToInstance(
             TokenMetadata,
@@ -25,7 +34,35 @@ export class TokensRepository {
                     aud: metadata.aud,
                     iat: metadata.iat,
                     exp: metadata.exp,
+                    nbf: metadata.nbf,
+                    pti: metadata.pti ?? null,
                 },
             })
         );
+
+    public update = async (token: TokenMetadata) =>
+        plainToInstance(
+            TokenMetadata,
+            await this.databaseService.token.update({
+                where: { jti: token.jti },
+                data: {
+                    tpe: token.tpe,
+                    rvk: token.rvk,
+                    sub: token.sub,
+                    iss: token.iss,
+                    aud: token.aud,
+                    iat: token.iat,
+                    exp: token.exp,
+                    nbf: token.nbf,
+                },
+            })
+        );
+
+    public async removeByJti(jti: string) {
+        await this.databaseService.token.delete({ where: { jti: jti } });
+    }
+
+    public async removeAllBySub(userId: string) {
+        await this.databaseService.token.deleteMany({ where: { sub: userId } });
+    }
 }

--- a/src/app/shared/authentication.models.ts
+++ b/src/app/shared/authentication.models.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsNotEmpty, IsOptional, IsString, IsUrl, MinLength } from 'class-validator';
+import { IsBoolean, IsDate, IsNotEmpty, IsOptional, IsString, IsUrl, MinLength, ValidateIf } from 'class-validator';
 
 /** Maximum lifetime of an authorization code in ms, which currently is set to 5 minutes. */
 export const MAX_AUTHORIZATION_CODE_LIFETIME = 300_000 as const;
@@ -90,11 +90,17 @@ export class LoginData extends MessageWithState {
 export class TokenRequestData {
     @IsString()
     @IsNotEmpty()
-    public authorizationCode: string;
+    @ValidateIf((object) => !object.useRefreshToken)
+    public authorizationCode?: string;
 
     @IsString()
     @IsNotEmpty()
-    public codeVerifier: string;
+    @ValidateIf((object) => !object.useRefreshToken)
+    public codeVerifier?: string;
+
+    @IsBoolean()
+    @ValidateIf((object) => object.useRefreshToken)
+    public useRefreshToken?: boolean;
 }
 
 export class ChangePasswordData {

--- a/src/app/shared/token.models.ts
+++ b/src/app/shared/token.models.ts
@@ -7,8 +7,8 @@ export const ACCESS_TOKEN_EXPIRATION_TIME = 900_000 as const;
 /** Expiration time of the refresh token in ms, which is currently set at seven days. */
 export const REFRESH_TOKEN_EXPIRATION_TIME = 604_800_000 as const;
 
-/** The time in ms after which the refresh token can be used, which is currently set to two minutes before seven days. */
-export const REFRESH_TOKEN_NBF = 604_680_000 as const;
+/** The time in ms after which the refresh token can be used, which is currently set to 13 minutes. */
+export const REFRESH_TOKEN_NBF = 780_000 as const;
 
 export const TokenTypes = {
     ACCESS: 'ACCESS',

--- a/src/app/shared/token.models.ts
+++ b/src/app/shared/token.models.ts
@@ -40,6 +40,7 @@ export interface DecodedToken {
     };
     payload: {
         jti: string;
+        pti?: string;
         sub: string;
         iss: string;
         aud: string;

--- a/tools/generate-code-verifier-and-challenge.ts
+++ b/tools/generate-code-verifier-and-challenge.ts
@@ -1,0 +1,13 @@
+import { createHash } from 'crypto';
+import { nanoid } from 'nanoid';
+
+function generateCodeVerifierAndChallenge() {
+    const codeVerifier = Buffer.from(nanoid(43)).toString('base64url');
+    const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+
+    const state = nanoid();
+
+    console.log({ codeVerifier, codeChallenge, state });
+}
+
+generateCodeVerifierAndChallenge();


### PR DESCRIPTION
* The `/server/authorize` can now accept refresh tokens in order to create new access and refresh token in order to extend a user's session without needing extra input from the user.