### PR TITLE
Send access tokens per client

### DIFF
--- a/src/app/authentication/authentication.controller.ts
+++ b/src/app/authentication/authentication.controller.ts
@@ -15,6 +15,7 @@ import { DmaLogger } from '../logging';
 import {
     AuthorizeRequest,
     ChangePasswordData,
+    CLIENT_ID_HEADER,
     COOKIE_NAME_ACCESS_TOKEN,
     COOKIE_NAME_REFRESH_TOKEN,
     LoginData,
@@ -74,16 +75,17 @@ export class AuthenticationController {
         @Res({ passthrough: true }) response: FastifyReply
     ) {
         const receivedRefreshToken = retrieveSignedCookieValue(request, COOKIE_NAME_REFRESH_TOKEN, this.logger);
-        const { accessToken, refreshToken } = await this.authenticationService.requestToken(data, receivedRefreshToken);
+        const { tokens, clientId } = await this.authenticationService.requestToken(data, receivedRefreshToken);
 
         response
             .status(HttpStatus.OK)
-            .setCookie(COOKIE_NAME_ACCESS_TOKEN, accessToken.token, {
-                expires: accessToken.expirationTime,
+            .headers({ [CLIENT_ID_HEADER]: clientId })
+            .setCookie(`${COOKIE_NAME_ACCESS_TOKEN}-${clientId}`, tokens.accessToken.token, {
+                expires: tokens.accessToken.expirationTime,
                 path: '/',
             })
-            .setCookie(COOKIE_NAME_REFRESH_TOKEN, refreshToken.token, {
-                expires: refreshToken.expirationTime,
+            .setCookie(COOKIE_NAME_REFRESH_TOKEN, tokens.refreshToken.token, {
+                expires: tokens.refreshToken.expirationTime,
                 path: '/',
             });
     }

--- a/src/app/authentication/authentication.guard.ts
+++ b/src/app/authentication/authentication.guard.ts
@@ -2,7 +2,7 @@ import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from
 import { ModuleRef } from '@nestjs/core';
 import { FastifyRequest } from 'fastify';
 import { DmaLogger } from '../logging';
-import { COOKIE_NAME_ACCESS_TOKEN, TokenTypes } from '../shared';
+import { CLIENT_ID_HEADER, COOKIE_NAME_ACCESS_TOKEN, TokenTypes } from '../shared';
 import { validateCookie } from './functions';
 
 @Injectable()
@@ -16,9 +16,11 @@ export class AuthenticationGuard implements CanActivate {
 
     public async canActivate(context: ExecutionContext) {
         const request = context.switchToHttp().getRequest<FastifyRequest>();
+        const clientId = request.headers[CLIENT_ID_HEADER] as string;
+
         const decodedToken = await validateCookie({
             request: request,
-            cookieName: COOKIE_NAME_ACCESS_TOKEN,
+            cookieName: `${COOKIE_NAME_ACCESS_TOKEN}-${clientId}`,
             moduleRef: this.moduleRef,
             logger: this.logger,
         });

--- a/src/app/authentication/authentication.service.ts
+++ b/src/app/authentication/authentication.service.ts
@@ -124,7 +124,10 @@ export class AuthenticationService {
 
         this.logger.log(`Request for tokens succeeded. Creating tokens for User with ID "${userId}"`);
 
-        return await this.tokensService.generateTokens(client, userId);
+        return {
+            tokens: await this.tokensService.generateTokens(client, userId),
+            clientId: client.id,
+        };
     }
 
     private async updateAuthorization(state: string, userId: string) {
@@ -164,6 +167,9 @@ export class AuthenticationService {
                 return this.tokensService.update(token);
             })
         );
-        return await this.tokensService.generateTokens(client, sub, jti);
+        return {
+            tokens: await this.tokensService.generateTokens(client, sub, jti),
+            clientId: client.id,
+        };
     }
 }

--- a/src/app/shared/authentication.models.ts
+++ b/src/app/shared/authentication.models.ts
@@ -5,7 +5,7 @@ export const MAX_AUTHORIZATION_CODE_LIFETIME = 300_000 as const;
 
 export const COOKIE_NAME_ACCESS_TOKEN = '__Host-Access-Token';
 
-export const CLIENT_ID_HEADER = 'dma_client_id';
+export const CLIENT_ID_HEADER = 'Dma-Client-Id';
 
 export const COOKIE_NAME_REFRESH_TOKEN = '__Host-Refresh-Token';
 

--- a/src/app/shared/authentication.models.ts
+++ b/src/app/shared/authentication.models.ts
@@ -5,6 +5,8 @@ export const MAX_AUTHORIZATION_CODE_LIFETIME = 300_000 as const;
 
 export const COOKIE_NAME_ACCESS_TOKEN = '__Host-Access-Token';
 
+export const CLIENT_ID_HEADER = 'dma_client_id';
+
 export const COOKIE_NAME_REFRESH_TOKEN = '__Host-Refresh-Token';
 
 export class SignUpData {

--- a/src/app/tokens/tokens.service.ts
+++ b/src/app/tokens/tokens.service.ts
@@ -37,17 +37,18 @@ export class TokensService {
         const key = await this.keysService.getKeysByClientId(client.id);
 
         const params = {
-            audience: client.audience,
             userId: userId,
             pti: pti,
             key: key,
         };
         const accessToken = await this.generateToken({
             ...params,
+            audience: client.audience,
             tokenType: TokenTypes.ACCESS,
         });
         const refreshToken = await this.generateToken({
             ...params,
+            audience: 'dnd-mapp/authorization-server',
             tokenType: TokenTypes.REFRESH,
         });
 


### PR DESCRIPTION
* The access token cookie with have a suffix containing the client ID for which the token is intended. Along with the cookies containing the JWTs, a header `Dma-Client-Id` will be send containing the same ID. This header value should be stored and the same header should be send along every following authenticated requests so that the authorization server can grab the correct access token for decoding and verifying authentication and authorization.
* Refresh tokens will now always have the authorization server as targeted audience.