### PR TITLE
Fix reading client-id header during accessing the access token

### DIFF
--- a/src/app/authentication/authentication.guard.ts
+++ b/src/app/authentication/authentication.guard.ts
@@ -16,7 +16,7 @@ export class AuthenticationGuard implements CanActivate {
 
     public async canActivate(context: ExecutionContext) {
         const request = context.switchToHttp().getRequest<FastifyRequest>();
-        const clientId = request.headers[CLIENT_ID_HEADER] as string;
+        const clientId = request.headers[CLIENT_ID_HEADER.toLowerCase()] as string;
 
         const decodedToken = await validateCookie({
             request: request,


### PR DESCRIPTION
* Fixed a bug where the "Dma-Client-Id" header wasn't read properly thus the authentication/authorization failed when using the access token.