### PR TITLE
Remove postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "type": "git"
     },
     "scripts": {
-        "postinstall": "npx prisma generate",
         "clean": "npx ts-node tools/clean.ts",
         "build": "npx nest build",
         "build-dev": "npx nest build -w",


### PR DESCRIPTION
The publish pipeline was failing because of the postinstall hook. It tried to generate the Prisma client, but the schema wasn't copied over to the Docker Image layer yet. In order to keep the Docker build fast by caching the install of dependencies, the postinstall hook has been removed in favor of altering the Dockerfile.

This means that after every install of node_modules, the Prisma client needs to be generated manually!